### PR TITLE
Create redirect-to-new-address-subdomain-wp

### DIFF
--- a/redirect-to-new-address-subdomain-wp
+++ b/redirect-to-new-address-subdomain-wp
@@ -1,0 +1,13 @@
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteBase /
+RewriteCond %{HTTP_HOST} !^(subdomain\.)?newsite\.com$
+RewriteCond $1 !^(exclude\.html)
+RewriteRule (.*) http://subdomain.newsite.com/$1 [L,R=301]
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress


### PR DESCRIPTION
This .htaccess file is designed for WordPress websites to handle 301 redirections to a new subdomain while excluding specific files. It ensures that any traffic from an old domain is redirected to a new subdomain (e.g., subdomain.newsite.com). The file preserves the URL structure of the requests and is fully compatible with WordPress installations. It also ensures that certain files (like exclude.html) are not redirected.